### PR TITLE
README.md: extended installation/configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added `--stop-before-deepsea-stage` option to CLI
 - Installation instructions to the README.md
 
+### Changed
+- Use `libvirt_use_ssh` instead of `libvirt_use_ssl` to configure SSH access
+
 ### Fixed
 - remove `qemu_use_session` vagrant-libvirt setting when packaging for Fedora 29
 - Use `RSA#exportKey` method to work with version 3.4.6 of pycrytodomex

--- a/README.md
+++ b/README.md
@@ -1,22 +1,32 @@
 # sesdev - CLI tool to deploy and manage SES/Ceph clusters
 
-`sesdev` is a CLI tool to deploy Ceph clusters (both the upstream and SUSE downstream versions).
-This tool uses Vagrant behind the scenes to create the VMs and run the deployment scripts.
+`sesdev` is a CLI tool to deploy Ceph clusters (both the upstream and SUSE
+downstream versions).
 
-## Instalation
+This tool uses [Vagrant](https://www.vagrantup.com/) behind the scenes to create
+the VMs and run the deployment scripts.
 
-First, you should have both QEMU and Libvirt installed in some machine to host the VMs created by
-sesdev (using Vagrant behind the scenes).
+## Installation
 
-### Install KVM/QEMU + Libvirt in openSUSE Leap 15
+First, you should have both [QEMU](https://www.qemu.org/) and
+[Libvirt](https://libvirt.org/) installed in some machine to host the VMs
+created by sesdev (using Vagrant behind the scenes).
+
+Installable packages for various Linux distributions like Fedora or openSUSE can be
+found on the [openSUSE Build Service](https://software.opensuse.org//download.html?project=home%3Arjdias&package=sesdev) (OBS).
+
+### Installation on openSUSE
+
+#### Install KVM/QEMU + Libvirt
 
 ```
-$ sudo zypper -n install patterns-openSUSE-kvm_server patterns-server-kvm_tools bridge-utils
+$ sudo zypper -n install patterns-openSUSE-kvm_server \
+patterns-server-kvm_tools bridge-utils
 $ sudo systemctl enable libvirtd
 $ sudo systemctl restart libvirtd
 ```
 
-### Install sesdev from package (openSUSE)
+#### Install sesdev from package
 
 ```
 $ sudo zypper ar https://download.opensuse.org/repositories/home:/rjdias/<repo> sesdev_repo
@@ -27,30 +37,69 @@ $ sudo zypper install sesdev
 
 Where `<repo>` can be either `openSUSE_Leap_15.1` or `openSUSE_Tumbleweed`.
 
+### Installation on Fedora Linux
+
+#### Install KVM/QEMU + Libvirt
+
+```
+$ sudo dnf install qemu-common qemu-kvm libvirt-daemon-kvm \
+libvirt-daemon libvirt-daemon-driver-qemu vagrant-libvirt
+$ sudo systemctl enable libvirtd
+$ sudo systemctl restart libvirtd
+```
+
+#### Install sesdev from package
+
+```
+$ sudo dnf config-manager --add-repo \
+https://download.opensuse.org/repositories/home:rjdias/<distro>/home:rjdias.repo
+dnf install sesdev
+```
+
+Where `<distro>` can be either `Fedora_29` or `Fedora_30`.
 
 ## Usage
 
 ### Create/Deploy cluster
 
-To create a single node Ceph cluster based on nautilus/leap-15.1:
+To create a single node Ceph cluster based on nautilus/leap-15.1 on your local
+system, run the following command:
 
 ```
 $ sesdev create --single-node mini
 ```
 
-The `mini` argument is the ID of the deployment. We can create many deployments by giving
-different IDs.
+The `mini` argument is the ID of the deployment. We can create many deployments
+by giving them different IDs.
 
-To create a multi node Ceph cluster we can specify the roles of each node:
+If you would like to start the cluster VMs on a remote server via libvirt/SSH,
+create a configuration file `$HOME/.sesdev/config.yaml` with the following
+content:
+
+```
+libvirt_use_ssh: true
+libvirt_user: <ssh_user>
+libvirt_host: <hostname|ip address>
+```
+
+Note that passwordless SSH access to this user@host combination needs to be
+configured and enabled.
+
+To create a multi-node Ceph cluster, we can specify the roles of each node as
+follows:
 
 ```
 $ sesdev create --roles="[admin, mon], [storage, mon, mgr, mds], [storage, mon, mgr, mds], [igw, ganesha, rgw]" big_cluster
 
 ```
 
-The cluster generated will have 4 nodes: the admin node that is running the salt-master and one
-MON, two storage nodes that will also run a MON, a MGR and an MDS, and another node that will
-run an iSCSI gateway, nfs-ganesha gateway, and an RGW gateway.
+The roles of each node are grouped in square brackets, separated by commas. The
+nodes are separated by commas, too.
+
+The cluster generated will have 4 nodes: the admin node that is running the
+salt-master and one MON, two storage nodes that will also run a MON, a MGR and
+an MDS, and another node that will run an iSCSI gateway, nfs-ganesha gateway,
+and an RGW gateway.
 
 ### Listing deployments
 
@@ -64,8 +113,8 @@ $ sesdev list
 $ sesdev ssh <deployment_id> [NODE]
 ```
 
-Spawns an SSH shell to the admin node, or to node `NODE` if explicitly specified. You can check
-the existing node names with the following command:
+Spawns an SSH shell to the admin node, or to node `NODE` if explicitly
+specified. You can check the existing node names with the following command:
 
 ```
 $ sesdev info <deployment_id>
@@ -73,9 +122,8 @@ $ sesdev info <deployment_id>
 
 ### Services port-forwarding
 
-It's possible to use an SSH tunnel to create a port-forwarding for a service running in the
-cluster.
-Currently only the dashboard service is implemented.
+It's possible to use an SSH tunnel to enble TCP port-forwarding for a service
+running in the cluster. Currently, only the dashboard service is implemented.
 
 ```
 $ sesdev tunnel <deployment_id> dashboard

--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -62,9 +62,9 @@ SETTINGS = {
         'help': 'Username to use to login into the libvirt host',
         'default': None
     },
-    'libvirt_use_ssl': {
+    'libvirt_use_ssh': {
         'type': bool,
-        'help': 'Flag to control the use of SSL when connecting to the libvirt host',
+        'help': 'Flag to control the use of SSH when connecting to the libvirt host',
         'default': None
     },
     'libvirt_storage_pool': {
@@ -275,7 +275,7 @@ class Deployment(object):
         return template.render(**{
             'libvirt_host': self.settings.libvirt_host,
             'libvirt_user': self.settings.libvirt_user,
-            'libvirt_use_ssl': 'true' if self.settings.libvirt_use_ssl else 'false',
+            'libvirt_use_ssh': 'true' if self.settings.libvirt_use_ssh else 'false',
             'libvirt_storage_pool': self.settings.libvirt_storage_pool,
             'ram': self.settings.ram * 2**10,
             'cpus': self.settings.cpus,

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -12,8 +12,8 @@ Vagrant.configure("2") do |config|
 {% if libvirt_user %}
     lv.username = "{{ libvirt_user }}"
 {% endif %}
-{% if libvirt_use_ssl %}
-    lv.connect_via_ssh = {{ libvirt_use_ssl }}
+{% if libvirt_use_ssh %}
+    lv.connect_via_ssh = {{ libvirt_use_ssh }}
 {% endif %}
     lv.qemu_use_session = false
 


### PR DESCRIPTION
Several improvements to the docs and one config setting:

Use `libvirt_use_ssh` instead `libvirt_use_ssl`.
Added Fedora Linux installation instructions.
Added hints on how to configure remote SSH access.
Improved formatting and wording in a couple of places.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>