### PR TITLE
setup.py: add missing template directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv*
+virtualenv*
 .vscode
 **/__pycache__
 *.log

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ To create a multi-node Ceph cluster, we can specify the roles of each node as
 follows:
 
 ```
-$ sesdev create --roles="[admin, mon], [storage, mon, mgr, mds], [storage, mon, mgr, mds], [igw, ganesha, rgw]" big_cluster
+$ sesdev create nautilus --roles="[admin, mon], [storage, mon, mgr, mds], [storage, mon, mgr, mds], [igw, ganesha, rgw]" big_cluster
 
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,11 @@ setup(
     py_modules=['sesdev'],
     packages=['seslib'],
     package_data={
-        'seslib': ['templates/*.j2']
+        'seslib': [
+            'templates/*.j2',
+            'templates/deepsea/*.j2',
+            'templates/engine/*.j2'
+        ]
     },
     install_requires=[
         "Click >= 6.7",


### PR DESCRIPTION
Address the following error:

```
smithfarm@vanguard1:~> sesdev create ses6 --single-node mini
Traceback (most recent call last):
  File "/usr/bin/sesdev", line 11, in <module>
    load_entry_point('sesdev==1.0.0+1573749027.g0e3c988', 'console_scripts', 'sesdev')()
  File "/usr/lib/python3.6/site-packages/sesdev.py", line 16, in sesdev_main
    cli(prog_name='sesdev')
  File "/usr/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/sesdev.py", line 324, in ses6
    _create_command(deployment_id, deploy, settings_dict)
  File "/usr/lib/python3.6/site-packages/sesdev.py", line 274, in _create_command
    dep = seslib.Deployment.create(deployment_id, settings)
  File "/usr/lib/python3.6/site-packages/seslib/__init__.py", line 737, in create
    dep._save()
  File "/usr/lib/python3.6/site-packages/seslib/__init__.py", line 469, in _save
    vagrant_file = self.generate_vagrantfile()
  File "/usr/lib/python3.6/site-packages/seslib/__init__.py", line 465, in generate_vagrantfile
    'os_base_repos': os_base_repos,
  File "/usr/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/usr/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.6/site-packages/seslib/templates/Vagrantfile.j2", line 8, in top-level template code
    {% include "engine/" + vm_engine + "/vagrant.provider.j2" %}
  File "/usr/lib/python3.6/site-packages/jinja2/loaders.py", line 235, in get_source
    raise TemplateNotFound(template)
jinja2.exceptions.TemplateNotFound: engine/libvirt/vagrant.provider.j2
```