### PR TITLE
setup.py: fix engine/libvirt template directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'seslib': [
             'templates/*.j2',
             'templates/deepsea/*.j2',
-            'templates/engine/*.j2'
+            'templates/engine/libvirt/*.j2'
         ]
     },
     install_requires=[


### PR DESCRIPTION
b9e55088fe7f8603222a06a83b94da11203687c5 fixed the deepsea templates packaging,
but the engine/libvirt templates are still missing in the RPM package.

Signed-off-by: Nathan Cutler <ncutler@suse.com>