### PR TITLE
Add Github Action to publish to OBS

### DIFF
--- a/.github/workflows/obs-publish.yml
+++ b/.github/workflows/obs-publish.yml
@@ -1,0 +1,20 @@
+name: Upload OBS Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish to OBS
+      uses: tspmelo/publish-obs-action@master
+      with:
+        obs user:  ${{ secrets.OBS_USERNAME }}
+        obs pass:  ${{ secrets.OBS_PASSWORD }}
+        obs email:  ${{ secrets.OBS_EMAIL }}
+        obs project:  ${{ secrets.OBS_PROJECT }}
+        obs package:  ${{ secrets.OBS_PACKAGE }}
+        full name:  ${{ secrets.FULL_NAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add Github Action to publish to OBS
+
 ### Fixed
 - Handle Ctrl+C on deployment creation (PR #8)
 


### PR DESCRIPTION
This action will be triggered on a release creation and
will publish a new package revision in OBS.

Signed-off-by: Tiago Melo <tmelo@suse.com>