### PR TITLE
Implement --repo-priority / --no-repo-priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ $ source venv/bin/activate
 $ pip install --editable .
 ```
 
-Remember to re-run `pip install` after each git pull.
+Remember to re-run `pip install --editable .` after each git pull.
 
 ## Usage
 
@@ -132,6 +132,21 @@ The cluster generated will have 4 nodes: the admin node that is running the
 salt-master and one MON, two storage nodes that will also run a MON, a MGR and
 an MDS, and another node that will run an iSCSI gateway, nfs-ganesha gateway,
 and an RGW gateway.
+
+#### Custom zypper repos
+
+If you have the URL(s) of custom zypper repo(s) that you would like to add
+to all the nodes of the cluster prior to deployment, add one or more
+`--repo` options to the command line, e.g.:
+
+```
+$ sesdev create nautilus --single-node --repo [URL_OF_REPO] mini
+```
+
+By default, the custom repo(s) will be added with an elevated priority,
+to ensure that packages from these repos will be installed even if higher
+RPM versions of those packages exist. If this behavior is not desired,
+add `--no-repo-priority` to disable it.
 
 ### Listing deployments
 

--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -72,7 +72,9 @@ def common_create_options(func):
         click.option('--single-node/--no-single-node', default=False,
                      help='Deploy a single node cluster. Overrides --roles'),
         click.option('--repo', multiple=True, type=str, default=None,
-                     help='Zypper repo URL. The repo will be added to each node.'),
+                     help='Custom zypper repo URL. The repo will be added to each node.'),
+        click.option('--repo-priority/--no-repo-priority', default=True,
+                     help="Automatically set priority on custom zypper repos"),
         click.option('--scc-user', type=str, default=None,
                      help='SCC organization username'),
         click.option('--scc-pass', type=str, default=None,
@@ -215,7 +217,8 @@ def create():
 
 def _gen_settings_dict(version, roles, os, num_disks, single_node, libvirt_host, libvirt_user,
                        libvirt_storage_pool, deepsea_cli, stop_before_deepsea_stage, deepsea_repo,
-                       deepsea_branch, repo, cpus, ram, disk_size, vagrant_box, scc_user, scc_pass):
+                       deepsea_branch, repo, cpus, ram, disk_size, repo_priority, vagrant_box,
+                       scc_user, scc_pass):
 
     settings_dict = {}
     if not single_node and roles:
@@ -269,6 +272,9 @@ def _gen_settings_dict(version, roles, os, num_disks, single_node, libvirt_host,
 
     if repo:
         settings_dict['repos'] = list(repo)
+
+    if repo_priority is not None:
+        settings_dict['repo_priority'] = repo_priority
 
     if vagrant_box:
         settings_dict['vagrant_box'] = vagrant_box

--- a/seslib/templates/Vagrantfile.j2
+++ b/seslib/templates/Vagrantfile.j2
@@ -36,7 +36,6 @@ zypper ar {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}
 
 zypper ar {{ version_repo }} {{ version }}-repo
-zypper mr -p 95 {{ version }}-repo
 
 zypper --gpg-auto-import-keys ref
 
@@ -48,7 +47,7 @@ zypper -n install vim git iputils hostname jq make iptables patch
 
 {% for repo in node.repos %}
 zypper ar {{ repo.url }} {{ repo.name }}
-{% if repo.priority %}
+{% if repo_priority and repo.priority %}
 zypper mr -p {{ repo.priority }} {{ repo.name }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This commit provides a way to turn off the current behavior where sesdev adds
custom repos with an elevated priority.

Also, it drops the setting of elevated priority on repos hard-coded in
VERSION_OS_REPO_MAPPING. These repos are controlled by package maintainers and
are not expected to need elevated priority.

Fixes: https://github.com/rjfd/sesdev/issues/18
Signed-off-by: Nathan Cutler <ncutler@suse.com>