### PR TITLE
Fix --single-node regression

### DIFF
--- a/sesdev/__init__.py
+++ b/sesdev/__init__.py
@@ -234,10 +234,8 @@ def _gen_settings_dict(version, roles, os, num_disks, single_node, libvirt_host,
         settings_dict['roles'] = _parse_roles(roles)
     elif single_node:
         settings_dict['roles'] = _parse_roles("["
-                                              " ["
                                               "   admin, storage, mon, mgr, prometheus,"
                                               "   grafana, mds, igw, rgw, ganesha"
-                                              " ]"
                                               "]"
                                               )
 


### PR DESCRIPTION
Before 42a541c735d1f3a015b0c22a904d0a0ec2a760f5, --single-node was working fine.
After, it was broken:

```
(v) smithfarm@vanguard1:~/sesdev> sesdev create ses6 --single-node mini
=== Creating deployment with the following configuration ===
Deployment VMs:
  -- node1:
     - OS:               sles-15-sp1
     - ses_version:      ses6
     - roles:            ['grafana', 'ganesha ]', 'prometheus', 'mds', 'mon', 'igw', 'rgw', 'mgr', '[   admin', 'storage']
```

Fixes: 42a541c735d1f3a015b0c22a904d0a0ec2a760f5
Fixes: https://github.com/rjfd/sesdev/issues/25
Signed-off-by: Nathan Cutler <ncutler@suse.com>