### PR TITLE
Display amount of deployed VMs in status output

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -669,7 +669,7 @@ class Deployment():
                         self.nodes[line_arr[0]].status = "suspended"
 
     def status(self):
-        result = "Deployment VMs:\n"
+        result = "{} Deployment VMs:\n".format(len(self.nodes))
         for k, v in self.nodes.items():
             result += "  -- {}:\n".format(k)
             if v.status:


### PR DESCRIPTION
Adds the number of VMs in a deployment to the status output.

Signed-off-by: Lenz Grimmer <lenz@grimmer.com>