### PR TITLE
Enable display of manpages

### DIFF
--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -20,9 +20,9 @@ zypper ar -f http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2/SUSE:CA.repo
 zypper --gpg-auto-import-keys ref
 
 {% if version == 'ses5' %}
-zypper -n install vim git-core iputils jq make iptables patch
+zypper -n install vim git-core iputils jq make iptables patch man
 {% else %}
-zypper -n install vim git iputils hostname jq make iptables patch
+zypper -n install vim git iputils hostname jq make iptables patch man
 {% endif %}
 
 {% if version == 'ses7' %}

--- a/seslib/templates/provision.sh.j2
+++ b/seslib/templates/provision.sh.j2
@@ -4,6 +4,8 @@
 echo "{{ _node.public_address }} {{ _node.fqdn }} {{ _node.name }}" >> /etc/hosts
 {% endfor %}
 
+sed -i 's/^rpm\.install\.excludedocs.*$/# rpm.install.excludedocs = no/' /etc/zypp/zypp.conf
+
 {% for os_repo_name, os_repo_url in os_base_repos %}
 zypper ar {{ os_repo_url }} {{ os_repo_name }}
 {% endfor %}


### PR DESCRIPTION
As a convenience, let users of sesdev install and display manpages inside their clusters.