### PR TITLE
RFC: ceph_bootstrap_deployment.sh: Also set -e

### DIFF
--- a/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
+++ b/seslib/templates/ceph-bootstrap/ceph_bootstrap_deployment.sh.j2
@@ -1,5 +1,5 @@
 
-set -x
+set -ex
 
 {% if ceph_bootstrap_git_repo %}
 cd /root


### PR DESCRIPTION
I've had the odd experience that `zypper in` failed, but bootstrapping continued.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>