### PR TITLE
Use SES7 Media1 repo instead of "standard"

### DIFF
--- a/seslib/__init__.py
+++ b/seslib/__init__.py
@@ -92,7 +92,7 @@ OS_REPOS = {
         'container-apps-update': 'http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/'
                                  '15-SP2/x86_64/update/',
         'storage-update': 'http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/SES7/'
-                          'standard/',
+                          'images/repo/SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/',
     },
 }
 


### PR DESCRIPTION
The "standard" repo is missing a bunch of packages that are needed for SES7
deployment.

Signed-off-by: Ricardo Dias <ricardo.dias@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>
