### PR TITLE
Enable linter via travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ virtualenv*
 Pipfile
 build
 dist
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+matrix:
+  include:
+  - python: 3.6
+    env: TOX_ENV=py36
+  - python: 3.7
+    env: TOX_ENV=py37
+  - python: 3.7
+    env: TOX_ENV=lint
+install:
+- pip install tox
+script:
+- tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist = py36,py37,lint
+minversion = 2.4
+skipsdist = True
+
+[testenv]
+usedevelop = True
+install_command = pip install {opts} {packages}
+extras = dev
+
+[testenv:lint]
+basepython = python3
+commands =
+  pylint seslib
+  pycodestyle seslib
+  pylint sesdev
+  pycodestyle sesdev


### PR DESCRIPTION
Add very basic testing when doing pull requests via TravisCI and
tox. The tests can also be executed manually with eg. "tox -elint" for
the linters.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>